### PR TITLE
Add docker daemon socket proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,18 @@
 version: '3'
 
 services:
+  docker-socket-proxy:
+    # https://hub.docker.com/r/tecnativa/docker-socket-proxy
+    iamge: tecnativa/docker-socket-proxy
+    container_name: docker-socket-proxy
+    restart: unless-stopped
+    privileged: true
+    networks:
+      - socket-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - CONTAINERS="1"
   traefik:
     # https://hub.docker.com/_/traefik/
     image: traefik:${TRAEFIK_TAG}
@@ -8,11 +20,11 @@ services:
     restart: unless-stopped
     networks:
       - web-proxy
+      - socket-proxy
     ports:
       - 80:80
       - 443:443
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - ${LOCAL_STORAGE}/traefik/config/traefik.toml:/etc/traefik/traefik.toml
       - ${LOCAL_STORAGE}/traefik/config/acme.json:/acme.json
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: traefik
     restart: unless-stopped
     networks:
-      - proxy
+      - web-proxy
     ports:
       - 80:80
       - 443:443
@@ -28,7 +28,7 @@ services:
     container_name: transmission
     restart: unless-stopped
     networks:
-      - proxy
+      - web-proxy
     cap_add:
       - NET_ADMIN
     devices:
@@ -142,7 +142,7 @@ services:
     container_name: sabnzbd
     restart: unless-stopped
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/sabnzbd/config:/config
       - ${MOUNT_POINT}/downloads/usenet/completed:/downloads:slave
@@ -163,7 +163,7 @@ services:
     container_name: jackett
     restart: unless-stopped
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/jackett/config:/config
       - ${MOUNT_POINT}/downloads/bittorrent/watch:/downloads:slave
@@ -182,7 +182,7 @@ services:
     container_name: nzbhydra
     restart: unless-stopped
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/nzbhydra/config:/config
       - ${MOUNT_POINT}/downloads/usenet/watching:/downloads:slave
@@ -206,7 +206,7 @@ services:
       - jackett
       - nzbhydra
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/radarr/config:/config
       - ${MOUNT_POINT}/downloads:/downloads:slave
@@ -231,7 +231,7 @@ services:
       - jackett
       - nzbhydra
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/sonarr/config:/config
       - ${MOUNT_POINT}/downloads:/downloads:slave
@@ -254,7 +254,7 @@ services:
       - radarr
       - sonarr
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/bazarr/config:/config
       - ${MOUNT_POINT}/medias/movies:/movies:slave
@@ -279,7 +279,7 @@ services:
       - jackett
       - nzbhydra
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/lidarr/config:/config
       - ${MOUNT_POINT}/downloads:/downloads:slave
@@ -304,7 +304,7 @@ services:
       - jackett
       - nzbhydra
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/lazylibrarian/config:/config
       - ${MOUNT_POINT}/downloads:/downloads:slave
@@ -330,7 +330,7 @@ services:
       - radarr
       - sonarr
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/ombi/config:/config
     environment:
@@ -348,7 +348,7 @@ services:
     container_name: plexmediaserver
     restart: unless-stopped
     networks:
-      - proxy
+      - web-proxy
     ports:
       - 32400:32400/tcp
       - 3005:3005/tcp
@@ -380,7 +380,7 @@ services:
     depends_on:
       - plexmediaserver
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/tautulli/config:/config
       - ${LOCAL_STORAGE}/plexmediaserver/db/Library/Application\ Support/Plex\ Media\ Server/Logs:/plex_logs:ro
@@ -399,7 +399,7 @@ services:
     container_name: calibre-web
     restart: unless-stopped
     networks:
-      - proxy
+      - web-proxy
     volumes:
       - ${LOCAL_STORAGE}/calibre-web/config:/config
       - ${MOUNT_POINT}/medias/books:/books:slave
@@ -460,7 +460,7 @@ services:
     depends_on:
       - nextcloud_mariadb
     networks:
-      - proxy
+      - web-proxy
       - internal
     volumes:
       - ${LOCAL_STORAGE}/nextcloud:/var/www/html
@@ -488,7 +488,7 @@ services:
     depends_on:
       - nextcloud
     networks:
-      - proxy
+      - web-proxy
     cap_add:
       - MKNOD
     environment:
@@ -504,7 +504,7 @@ services:
       - "traefik.http.services.office.loadbalancer.server.scheme=https"
 
 networks:
-  proxy:
+  web-proxy:
     external: true
   internal:
     external: true

--- a/fedora-setup.sh
+++ b/fedora-setup.sh
@@ -27,7 +27,7 @@ systemctl restart docker
 useradd dockerrt -d /nonexistent -u 3000 -U -s /usr/sbin/nologin
 
 # Create the docker networks
-docker network create proxy
+docker network create web-proxy
 docker network create internal
 
 # Install & setup NFS

--- a/fedora-setup.sh
+++ b/fedora-setup.sh
@@ -27,8 +27,9 @@ systemctl restart docker
 useradd dockerrt -d /nonexistent -u 3000 -U -s /usr/sbin/nologin
 
 # Create the docker networks
-docker network create web-proxy
 docker network create internal
+docker network create socket-proxy
+docker network create web-proxy
 
 # Install & setup NFS
 dnf -y install nfs-utils autofs

--- a/traefik.example.toml
+++ b/traefik.example.toml
@@ -23,7 +23,7 @@
   dashboard = true
 
 [providers.docker]
-  endpoint = "unix:///var/run/docker.sock"
+  endpoint = "tcp://docker-socket-proxy:2375"
   exposedByDefault = false
   network = "web-proxy"
 

--- a/traefik.example.toml
+++ b/traefik.example.toml
@@ -25,7 +25,7 @@
 [providers.docker]
   endpoint = "unix:///var/run/docker.sock"
   exposedByDefault = false
-  network = "proxy"
+  network = "web-proxy"
 
 [certificatesResolvers.le.acme]
   email = "postmaster@example.com"


### PR DESCRIPTION
In order to increase security, add a docker socket proxy container and remove direct access to the socket from Traefik. That way the socket is not accessible from a container that's accessible from outside.

The proxy is only accessible via the network `socket-proxy` of which only Traefik has access to. 