### PR TITLE
Rework books containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,8 +233,8 @@ services:
       traefik.http.routers.lidarr.entrypoints: 'websecure'
       traefik.http.services.lidarr.loadbalancer.server.port: '8686'
   lazylibrarian:
-    # https://hub.docker.com/r/thraxis/lazylibrarian-calibre
-    image: thraxis/lazylibrarian-calibre
+    # https://hub.docker.com/r/linuxserver/lazylibrarian
+    image: linuxserver/lazylibrarian
     container_name: lazylibrarian
     restart: unless-stopped
     depends_on:
@@ -255,6 +255,7 @@ services:
       TZ: '${TZ}'
       PUID: '${PUID}'
       PGID: '${PGID}'
+      DOCKER_MODS: 'linuxserver/calibre-web:calibre'
     labels:
       traefik.enable: 'true'
       traefik.http.routers.lazylibrarian.rule: 'Host(`lazylibrarian.${DOMAIN_NAME}`)'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,8 +249,6 @@ services:
       - ${MOUNT_POINT}/downloads:/downloads:slave,z
       - ${MOUNT_POINT}/medias/books:/books:slave,z
       - ${MOUNT_POINT}/medias/audiobooks:/audiobooks:slave,z
-      - ${MOUNT_POINT}/medias/magazines:/magazines:slave,z
-      - ${MOUNT_POINT}/medias/comics:/comics:slave,z
     environment:
       DOCKER_MODS: 'linuxserver/calibre-web:calibre'
       TZ: '${TZ}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,10 +252,10 @@ services:
       - ${MOUNT_POINT}/medias/magazines:/magazines:slave,z
       - ${MOUNT_POINT}/medias/comics:/comics:slave,z
     environment:
+      DOCKER_MODS: 'linuxserver/calibre-web:calibre'
       TZ: '${TZ}'
       PUID: '${PUID}'
       PGID: '${PGID}'
-      DOCKER_MODS: 'linuxserver/calibre-web:calibre'
     labels:
       traefik.enable: 'true'
       traefik.http.routers.lazylibrarian.rule: 'Host(`lazylibrarian.${DOMAIN_NAME}`)'
@@ -345,6 +345,7 @@ services:
       - ${LOCAL_STORAGE}/calibre-web/config:/config:Z
       - ${MOUNT_POINT}/medias/books:/books:slave,z
     environment:
+      DOCKER_MODS: 'linuxserver/calibre-web:calibre'
       TZ: '${TZ}'
       PUID: '${PUID}'
       PGID: '${PGID}'

--- a/docker-host-mount-points.example.txt
+++ b/docker-host-mount-points.example.txt
@@ -7,8 +7,6 @@
 /mnt/myserver/medias/audio_drama             -rw,vers=3    myserver:/path/to/medias/audio_drama
 /mnt/myserver/medias/audiobooks              -rw,vers=3    myserver:/path/to/medias/audiobooks
 /mnt/myserver/medias/books                   -rw,vers=3    myserver:/path/to/medias/books
-/mnt/myserver/medias/comics                  -rw,vers=3    myserver:/path/to/medias/comics
 /mnt/myserver/medias/movies                  -rw,vers=3    myserver:/path/to/medias/movies
 /mnt/myserver/medias/music                   -rw,vers=3    myserver:/path/to/medias/music
-/mnt/myserver/medias/podcasts                -rw,vers=3    myserver:/path/to/medias/podcasts
 /mnt/myserver/medias/tv_shows                -rw,vers=3    myserver:/path/to/medias/tv_shows

--- a/docker-host-setup.example.conf
+++ b/docker-host-setup.example.conf
@@ -1,7 +1,7 @@
 USER="myuser"
 STORAGE_SERVER_NAME="myserver"
 MOUNT_POINT="/mnt/${STORAGE_SERVER_NAME}"
-MOUNT_POINT_DIRS="${MOUNT_POINT}/cloud/data ${MOUNT_POINT}/downloads/bittorrent/{downloads,watch} ${MOUNT_POINT}/downloads/usenet/{completed,processing,watching} ${MOUNT_POINT}/medias/{audio_drama,audiobooks,books,comics,magazines,movies,music,podcasts,tv_shows}"
+MOUNT_POINT_DIRS="${MOUNT_POINT}/cloud/data ${MOUNT_POINT}/downloads/bittorrent/{downloads,watch} ${MOUNT_POINT}/downloads/usenet/{completed,processing,watching} ${MOUNT_POINT}/medias/{audio_drama,audiobooks,books,movies,music,tv_shows}"
 AUTO_MASTER="/-	/etc/auto.${STORAGE_SERVER_NAME} --ghost,--timeout=60"
 LOCAL_STORAGE="/opt/containers"
 LOCAL_STORAGE_DIRS="${LOCAL_STORAGE}/{bazarr,calibre-web,collaboraonline,jackett,lazylibrarian,lidarr,nzbhydra,ombi,openvpn-client,radarr,sabnzbd,sonarr,tautulli,traefik,transmission}/config ${LOCAL_STORAGE}/{nextcloud_mariadb,plexmediaserver}/db ${LOCAL_STORAGE}/nextcloud"


### PR DESCRIPTION
Switch to "official" LinuxServer's LazyLibrarian image.

It's now possible to add calibre import and conversion tools into the LazyLibrarian container, so the Thraxis image is not needed anymore.