### PR TITLE
Traefik hardening

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -409,6 +409,7 @@ services:
     environment:
       APACHE_DISABLE_REWRITE_IP: '1'
       TRUSTED_PROXIES: 'traefik'
+      OVERWRITEPROTOCOL: 'https'
       NEXTCLOUD_TRUSTED_DOMAINS: 'cloud.${DOMAIN_NAME}'
       MYSQL_DATABASE: '${MYSQL_DATABASE}'
       MYSQL_USER: '${MYSQL_USER}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - 443:443
     volumes:
       - ${LOCAL_STORAGE}/traefik/config/traefik.toml:/etc/traefik/traefik.toml:Z
+      - ${LOCAL_STORAGE}/traefik/config/traefik-dynamic.toml:/etc/traefik/traefik-dynamic.toml:Z
       - ${LOCAL_STORAGE}/traefik/config/acme.json:/acme.json:Z
     labels:
       traefik.enable: 'true'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.sabnzbd.rule: 'Host(`sabnzbd.${DOMAIN_NAME}`)'
       traefik.http.routers.sabnzbd.entrypoints: 'websecure'
-      traefik.http.routers.transmission.middlewares: 'set-security-headers@file'
+      traefik.http.routers.sabnzbd.middlewares: 'set-security-headers@file'
       traefik.http.services.sabnzbd.loadbalancer.server.port: '8080'
   jackett:
     # https://hub.docker.com/r/linuxserver/jackett/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       traefik.http.routers.traefik.rule: 'Host(`traefik.${DOMAIN_NAME}`)'
       traefik.http.routers.traefik.entrypoints: 'websecure'
       traefik.http.routers.traefik.service: 'api@internal'
-      traefik.http.routers.traefik.middlewares: 'traefik-auth'
+      traefik.http.routers.traefik.middlewares: 'set-security-headers@file, traefik-auth'
       traefik.http.middlewares.traefik-auth.basicauth.users: '${TRAEFIK_API_USER}:${TRAEFIK_API_PASSWORD}'
   transmission:
     # https://hub.docker.com/r/linuxserver/transmission
@@ -75,6 +75,7 @@ services:
       traefik.docker.network: 'vpn'
       traefik.http.routers.transmission.rule: 'Host(`transmission.${DOMAIN_NAME}`)'
       traefik.http.routers.transmission.entrypoints: 'websecure'
+      traefik.http.routers.transmission.middlewares: 'set-security-headers@file'
       traefik.http.services.transmission.loadbalancer.server.port: '9091'
   sabnzbd:
     # https://hub.docker.com/r/linuxserver/sabnzbd/
@@ -96,6 +97,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.sabnzbd.rule: 'Host(`sabnzbd.${DOMAIN_NAME}`)'
       traefik.http.routers.sabnzbd.entrypoints: 'websecure'
+      traefik.http.routers.transmission.middlewares: 'set-security-headers@file'
       traefik.http.services.sabnzbd.loadbalancer.server.port: '8080'
   jackett:
     # https://hub.docker.com/r/linuxserver/jackett/
@@ -115,6 +117,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.jackett.rule: 'Host(`jackett.${DOMAIN_NAME}`)'
       traefik.http.routers.jackett.entrypoints: 'websecure'
+      traefik.http.routers.jackett.middlewares: 'set-security-headers@file'
       traefik.http.services.jackett.loadbalancer.server.port: '9117'
   nzbhydra:
     # https://hub.docker.com/r/linuxserver/hydra2/
@@ -134,6 +137,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.nzbhydra.rule: 'Host(`nzbhydra.${DOMAIN_NAME}`)'
       traefik.http.routers.nzbhydra.entrypoints: 'websecure'
+      traefik.http.routers.nzbhydra.middlewares: 'set-security-headers@file'
       traefik.http.services.nzbhydra.loadbalancer.server.port: '5076'
   radarr:
     # https://hub.docker.com/r/linuxserver/radarr/
@@ -159,6 +163,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.radarr.rule: 'Host(`radarr.${DOMAIN_NAME}`)'
       traefik.http.routers.radarr.entrypoints: 'websecure'
+      traefik.http.routers.radarr.middlewares: 'set-security-headers@file'
       traefik.http.services.radarr.loadbalancer.server.port: '7878'
   sonarr:
     # https://hub.docker.com/r/linuxserver/sonarr/
@@ -184,6 +189,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.sonarr.rule: 'Host(`sonarr.${DOMAIN_NAME}`)'
       traefik.http.routers.sonarr.entrypoints: 'websecure'
+      traefik.http.routers.sonarr.middlewares: 'set-security-headers@file'
       traefik.http.services.sonarr.loadbalancer.server.port: '8989'
   bazarr:
     # https://hub.docker.com/r/linuxserver/bazarr
@@ -207,6 +213,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.bazarr.rule: 'Host(`bazarr.${DOMAIN_NAME}`)'
       traefik.http.routers.bazarr.entrypoints: 'websecure'
+      traefik.http.routers.bazarr.middlewares: 'set-security-headers@file'
       traefik.http.services.bazarr.loadbalancer.server.port: '6767'
   lidarr:
     # https://hub.docker.com/r/linuxserver/lidarr/
@@ -232,6 +239,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.lidarr.rule: 'Host(`lidarr.${DOMAIN_NAME}`)'
       traefik.http.routers.lidarr.entrypoints: 'websecure'
+      traefik.http.routers.lidarr.middlewares: 'set-security-headers@file'
       traefik.http.services.lidarr.loadbalancer.server.port: '8686'
   lazylibrarian:
     # https://hub.docker.com/r/linuxserver/lazylibrarian
@@ -259,6 +267,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.lazylibrarian.rule: 'Host(`lazylibrarian.${DOMAIN_NAME}`)'
       traefik.http.routers.lazylibrarian.entrypoints: 'websecure'
+      traefik.http.routers.lazylibrarian.middlewares: 'set-security-headers@file'
       traefik.http.services.lazylibrarian.loadbalancer.server.port: '5299'
   ombi:
     # https://hub.docker.com/r/linuxserver/ombi/
@@ -281,6 +290,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.ombi.rule: 'Host(`ombi.${DOMAIN_NAME}`)'
       traefik.http.routers.ombi.entrypoints: 'websecure'
+      traefik.http.routers.ombi.middlewares: 'set-security-headers@file'
       traefik.http.services.ombi.loadbalancer.server.port: '3579'
   plexmediaserver:
     # https://hub.docker.com/r/plexinc/pms-docker/
@@ -311,6 +321,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.plex.rule: 'Host(`plex.${DOMAIN_NAME}`)'
       traefik.http.routers.plex.entrypoints: 'websecure'
+      traefik.http.routers.plex.middlewares: 'set-security-headers@file'
       traefik.http.services.plex.loadbalancer.server.port: '32400'
   tautulli:
     # https://hub.docker.com/r/tautulli/tautulli/
@@ -332,6 +343,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.tautulli.rule: 'Host(`tautulli.${DOMAIN_NAME}`)'
       traefik.http.routers.tautulli.entrypoints: 'websecure'
+      traefik.http.routers.tautulli.middlewares: 'set-security-headers@file'
       traefik.http.services.tautulli.loadbalancer.server.port: '8181'
   calibre-web:
     # https://hub.docker.com/r/linuxserver/calibre-web
@@ -352,6 +364,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.calibre.rule: 'Host(`calibre.${DOMAIN_NAME}`)'
       traefik.http.routers.calibre.entrypoints: 'websecure'
+      traefik.http.routers.calibre.middlewares: 'set-security-headers@file'
       traefik.http.services.calibre.loadbalancer.server.port: '8083'
   nextcloud_mariadb:
     # https://hub.docker.com/_/mariadb/
@@ -420,7 +433,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.cloud.rule: 'Host(`cloud.${DOMAIN_NAME}`)'
       traefik.http.routers.cloud.entrypoints: 'websecure'
-      traefik.http.routers.cloud.middlewares: 'nextcloud-dav-redirect'
+      traefik.http.routers.cloud.middlewares: 'set-security-headers@file, nextcloud-dav-redirect'
       traefik.http.services.cloud.loadbalancer.server.port: '80'
       traefik.http.middlewares.nextcloud-dav-redirect.redirectRegex.permanent: 'true'
       traefik.http.middlewares.nextcloud-dav-redirect.redirectRegex.regex: 'https://(.*)/.well-known/(card|cal)dav'
@@ -445,6 +458,7 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.office.rule: 'Host(`office.${DOMAIN_NAME}`)'
       traefik.http.routers.office.entrypoints: 'websecure'
+      traefik.http.routers.office.middlewares: 'set-security-headers@file'
       traefik.http.services.office.loadbalancer.server.port: '9980'
       traefik.http.services.office.loadbalancer.server.scheme: 'https'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      TZ: '${TZ}'
       CONTAINERS: '1'
   openvpn-client:
     # https://hub.docker.com/r/dperson/openvpn-client
@@ -47,6 +48,8 @@ services:
       - ${LOCAL_STORAGE}/traefik/config/traefik.toml:/etc/traefik/traefik.toml:Z
       - ${LOCAL_STORAGE}/traefik/config/traefik-dynamic.toml:/etc/traefik/traefik-dynamic.toml:Z
       - ${LOCAL_STORAGE}/traefik/config/acme.json:/acme.json:Z
+    environment:
+      TZ: '${TZ}'
     labels:
       traefik.enable: 'true'
       traefik.http.routers.traefik.rule: 'Host(`traefik.${DOMAIN_NAME}`)'
@@ -377,6 +380,7 @@ services:
     volumes:
       - ${LOCAL_STORAGE}/nextcloud_mariadb/db:/var/lib/mysql:Z
     environment:
+      TZ: '${TZ}'
       MYSQL_ROOT_PASSWORD: '${MYSQL_ROOT_PASSWORD}'
       MYSQL_PASSWORD: '${MYSQL_PASSWORD}'
       MYSQL_DATABASE: '${MYSQL_DATABASE}'
@@ -388,6 +392,8 @@ services:
     restart: unless-stopped
     networks:
       - internal
+    environment:
+      TZ: '${TZ}'
   # Need that container in order to be able to use cron as a background job in Nextcloud
   # This container has one process running: cron, which execute /var/www/html/cron.php every 15 minutes
   # More info here: https://github.com/nextcloud/docker/pull/220
@@ -404,6 +410,8 @@ services:
     volumes:
       - ${LOCAL_STORAGE}/nextcloud:/var/www/html:z
       - ${MOUNT_POINT}/cloud/data:/var/www/html/data:slave,z
+    environment:
+      TZ: '${TZ}'
   nextcloud:
     # https://hub.docker.com/_/nextcloud/
     image: nextcloud:${NEXTCLOUD_TAG}
@@ -420,6 +428,7 @@ services:
       - ${MOUNT_POINT}/cloud/data:/var/www/html/data:slave,z
       - ${LOCAL_DOCUMENTS}:/mnt/documents:slave,z
     environment:
+      TZ: '${TZ}'
       APACHE_DISABLE_REWRITE_IP: '1'
       TRUSTED_PROXIES: 'traefik'
       OVERWRITEPROTOCOL: 'https'
@@ -450,6 +459,7 @@ services:
     cap_add:
       - MKNOD
     environment:
+      TZ: '${TZ}'
       domain: '${NEXTCLOUD_DOMAIN}'
       username: '${COLLABORA_USERNAME}'
       password: '${COLLABORA_PASSWORD}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       traefik.http.routers.traefik.rule: 'Host(`traefik.${DOMAIN_NAME}`)'
       traefik.http.routers.traefik.entrypoints: 'websecure'
       traefik.http.routers.traefik.service: 'api@internal'
-      traefik.http.routers.traefik.middlewares: 'traefik'
-      traefik.http.middlewares.traefik.basicauth.users: '${TRAEFIK_API_USER}:${TRAEFIK_API_PASSWORD}'
+      traefik.http.routers.traefik.middlewares: 'traefik-auth'
+      traefik.http.middlewares.traefik-auth.basicauth.users: '${TRAEFIK_API_USER}:${TRAEFIK_API_PASSWORD}'
   transmission:
     # https://hub.docker.com/r/linuxserver/transmission
     image: linuxserver/transmission
@@ -419,11 +419,11 @@ services:
       traefik.enable: 'true'
       traefik.http.routers.cloud.rule: 'Host(`cloud.${DOMAIN_NAME}`)'
       traefik.http.routers.cloud.entrypoints: 'websecure'
-      traefik.http.routers.cloud.middlewares: 'nextcloud'
+      traefik.http.routers.cloud.middlewares: 'nextcloud-dav-redirect'
       traefik.http.services.cloud.loadbalancer.server.port: '80'
-      traefik.http.middlewares.nextcloud.redirectRegex.permanent: 'true'
-      traefik.http.middlewares.nextcloud.redirectRegex.regex: 'https://(.*)/.well-known/(card|cal)dav'
-      traefik.http.middlewares.nextcloud.redirectRegex.replacement: 'https://$${1}/remote.php/dav/'
+      traefik.http.middlewares.nextcloud-dav-redirect.redirectRegex.permanent: 'true'
+      traefik.http.middlewares.nextcloud-dav-redirect.redirectRegex.regex: 'https://(.*)/.well-known/(card|cal)dav'
+      traefik.http.middlewares.nextcloud-dav-redirect.redirectRegex.replacement: 'https://$${1}/remote.php/dav/'
   collaboraonline:
     # https://hub.docker.com/r/collabora/code/
     image: collabora/code

--- a/fedora-setup.sh
+++ b/fedora-setup.sh
@@ -56,9 +56,10 @@ eval "mkdir -p ${LOCAL_STORAGE_DIRS}"
 chown -R dockerrt:dockerrt "${LOCAL_STORAGE}" && chmod -R 755 "${LOCAL_STORAGE}"
 
 # Copy configs where needed
-cp traefik.toml "${LOCAL_STORAGE}"/traefik/config/traefik.toml
+cp traefik.toml traefik-dynamic.toml "${LOCAL_STORAGE}"/traefik/config/
 touch "${LOCAL_STORAGE}"/traefik/config/acme.json && chmod 600 "${LOCAL_STORAGE}"/traefik/config/acme.json
-chown -R dockerrt:dockerrt "${LOCAL_STORAGE}"/traefik/config && chmod 755 "${LOCAL_STORAGE}"/traefik/config/traefik.toml
+chown -R dockerrt:dockerrt "${LOCAL_STORAGE}"/traefik/config
+chmod 755 "${LOCAL_STORAGE}"/traefik/config/traefik.toml "${LOCAL_STORAGE}"/traefik/config/traefik-dynamic.toml
 
 if [[ -f custom.ovpn ]]; then
   cp client.ovpn "${LOCAL_STORAGE}"/openvpn-client/config/client.ovpn

--- a/fedora-setup.sh
+++ b/fedora-setup.sh
@@ -59,7 +59,6 @@ chown -R dockerrt:dockerrt "${LOCAL_STORAGE}" && chmod -R 755 "${LOCAL_STORAGE}"
 cp traefik.toml traefik-dynamic.toml "${LOCAL_STORAGE}"/traefik/config/
 touch "${LOCAL_STORAGE}"/traefik/config/acme.json && chmod 600 "${LOCAL_STORAGE}"/traefik/config/acme.json
 chown -R dockerrt:dockerrt "${LOCAL_STORAGE}"/traefik/config
-chmod 755 "${LOCAL_STORAGE}"/traefik/config/traefik.toml "${LOCAL_STORAGE}"/traefik/config/traefik-dynamic.toml
 
 if [[ -f custom.ovpn ]]; then
   cp client.ovpn "${LOCAL_STORAGE}"/openvpn-client/config/client.ovpn

--- a/traefik-dynamic.toml
+++ b/traefik-dynamic.toml
@@ -11,3 +11,15 @@
       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
     ]
     curvePreferences = ["CurveP521","CurveP384"]
+
+[http]
+  [http.routers]
+    [http.routers.web-insecure]
+      entrypoints = ["web"]
+      rule = "HostRegexp(`{host:.+}`)"
+      service = "noop@internal"
+      middlewares = ["redirect-to-https"]
+  [http.middlewares]
+    [http.middlewares.redirect-to-https.redirectScheme]
+      scheme = "https"
+      permanent = true

--- a/traefik-dynamic.toml
+++ b/traefik-dynamic.toml
@@ -10,7 +10,7 @@
       "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
     ]
-    curvePreferences = ["X25519", "CurveP521","CurveP384"]
+    curvePreferences = ["X25519", "CurveP521", "CurveP384"]
 
 [http]
   [http.routers]

--- a/traefik-dynamic.toml
+++ b/traefik-dynamic.toml
@@ -10,7 +10,7 @@
       "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
       "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
     ]
-    curvePreferences = ["CurveP521","CurveP384"]
+    curvePreferences = ["X25519", "CurveP521","CurveP384"]
 
 [http]
   [http.routers]

--- a/traefik-dynamic.toml
+++ b/traefik-dynamic.toml
@@ -1,0 +1,13 @@
+[tls.options]
+  [tls.options.default]
+    minVersion = "VersionTLS12"
+    sniStrict = true
+    cipherSuites = [
+      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+    ]
+    curvePreferences = ["CurveP521","CurveP384"]

--- a/traefik-dynamic.toml
+++ b/traefik-dynamic.toml
@@ -23,3 +23,19 @@
     [http.middlewares.redirect-to-https.redirectScheme]
       scheme = "https"
       permanent = true
+    [http.middlewares.set-security-headers.headers]
+      browserXssFilter = true
+      contentTypeNosniff = true
+      customFrameOptionsValue = "SAMEORIGIN"
+      referrerPolicy = "same-origin"
+      featurePolicy = "vibrate 'none'"
+      stsSeconds = 31536000
+      stsIncludeSubdomains = true
+      # Only enable if the second level domain has TLS enabled
+      stsPreload = false
+      [http.middlewares.set-security-headers.headers.customRequestHeaders]
+        X-Scheme = "https"
+        X-Forwarded-Proto = "https"
+      [http.middlewares.set-security-headers.headers.customResponseHeaders]
+        X-Powered-By = ""
+        X-Robots-Tag = "none"

--- a/traefik.example.toml
+++ b/traefik.example.toml
@@ -29,6 +29,7 @@
     network = "web-proxy"
   [providers.file]
     filename = "/etc/traefik/traefik-dynamic.toml"
+    watch = true
 
 [certificatesResolvers.le.acme]
   email = "postmaster@example.com"

--- a/traefik.example.toml
+++ b/traefik.example.toml
@@ -22,10 +22,13 @@
 [api]
   dashboard = true
 
-[providers.docker]
-  endpoint = "tcp://docker-socket-proxy:2375"
-  exposedByDefault = false
-  network = "web-proxy"
+[providers]
+  [providers.docker]
+    endpoint = "tcp://docker-socket-proxy:2375"
+    exposedByDefault = false
+    network = "web-proxy"
+  [providers.file]
+    filename = "/etc/traefik/traefik-dynamic.toml"
 
 [certificatesResolvers.le.acme]
   email = "postmaster@example.com"

--- a/traefik.example.toml
+++ b/traefik.example.toml
@@ -6,7 +6,7 @@
   insecureSkipVerify = true
 
 [log]
-  level = "ERROR"
+  level = "WARNING"
 
 [entryPoints]
   [entryPoints.web]

--- a/traefik.example.toml
+++ b/traefik.example.toml
@@ -11,9 +11,6 @@
 [entryPoints]
   [entryPoints.web]
     address = ":80"
-    [entryPoints.web.http.redirections.entryPoint]
-      to = "websecure"
-      scheme = "https"
   [entryPoints.websecure]
     address = ":443"
     [entryPoints.websecure.http.tls]


### PR DESCRIPTION
My efforts to harden the configuration of Traefik.

- Set the minimum TLS version to 1.2
- Whitelist only the ciphers considered secure by Qualys SSL Labs
- Enable strict SNI checking
- Define a preference for elliptic curves
- Define headers in a middleware that is applied to all routers :
  - Response headers, to increase security
    - Set `X-XSS-Protection: 1; mode=block`
    - Set `X-Content-Type-Options: nosniff`
    - Set `X-Frame-Options: SAMEORIGIN`
    - Set `Referrer-Policy: same-origin`
    - Set `Feature-Policy: vibrate 'none'`
    - Set `Strict-Transport-Security: max-age=31536000; includeSubDomains`
    - Set `X-Robots-Tag: none`
    - Unset `X-Powered-By`
  - Requests headers, needed by some services to know that it's being accessed through a reverse proxy doing TLS termination
    - Set `X-Scheme: https`
    - Set `X-Forwarded-Proto: https`

All of this configuration is done in the `traefik-dynamic.toml` file. This file, separated from the `traefik.toml` file is needed in Traefik v2 because it introduces a clear separation between static and dynamic config. So every options considered dynamic by Traefik needs to go into a separate file referenced by the static file under the `[providers.file]` directive.