### PR TITLE
Switch to Sonarr v3 beta and add Flaresolverr container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,16 @@ services:
       traefik.http.routers.sabnzbd.entrypoints: 'websecure'
       traefik.http.routers.sabnzbd.middlewares: 'set-security-headers@file'
       traefik.http.services.sabnzbd.loadbalancer.server.port: '8080'
+  flaresolverr:
+    # https://hub.docker.com/r/flaresolverr/flaresolverr
+    image: flaresolverr/flaresolverr
+    container_name: flaresolverr
+    restart: unless-stopped
+    networks:
+      - web-proxy
+    environment:
+      TZ: '${TZ}'
+      CAPTCHA_SOLVER: 'hcaptcha-solver'
   jackett:
     # https://hub.docker.com/r/linuxserver/jackett/
     image: linuxserver/jackett

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,6 @@ services:
       TZ: '${TZ}'
       PUID: '${PUID}'
       PGID: '${PGID}'
-      HOST_WHITELIST_ENTRIES: 'sabnzbd.${DOMAIN_NAME}'
     labels:
       traefik.enable: 'true'
       traefik.http.routers.sabnzbd.rule: 'Host(`sabnzbd.${DOMAIN_NAME}`)'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,7 @@ services:
       traefik.http.services.radarr.loadbalancer.server.port: '7878'
   sonarr:
     # https://hub.docker.com/r/linuxserver/sonarr/
-    image: linuxserver/sonarr
+    image: linuxserver/sonarr:preview
     container_name: sonarr
     restart: unless-stopped
     networks:


### PR DESCRIPTION
- Switch to Sonarr v3 beta
  - The beta is pretty stable
    - The only remaining bug is related to Windows (Sonarr/Sonarr#3145)
  - I don't need the last missing feature blocking release (Sonarr/Sonarr#282)
- Add [Flaresolverr](https://github.com/FlareSolverr/FlareSolverr) container
  - Used to get around Cloudflare bot detection on some Jackett indexers