### PR TITLE
Upgrade Nextcloud to 22 and MariaDB to 10.6

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -33,7 +33,7 @@ PLEX_CLAIM=claim-xxxxxxxxxxxxxxxxxxxx
 ## Nextcloud
 NC_MARIADB_TAG=10
 NC_REDIS_TAG=6
-NEXTCLOUD_TAG=21
+NEXTCLOUD_TAG=22
 NC_MYSQL_ROOT_PASSWORD=supersecretpassword
 NC_MYSQL_PASSWORD=secretpassword
 NC_MYSQL_DATABASE=nextcloud

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -476,7 +476,7 @@ services:
     image: mariadb:${NC_MARIADB_TAG}
     container_name: nextcloud_mariadb
     restart: unless-stopped
-    command: --transaction-isolation=READ-COMMITTED --log-bin --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW --skip-innodb-read-only-compressed
     networks:
       - internal
     volumes:


### PR DESCRIPTION
- Upgrade Nextcloud to version 22
- Upgrade MariaDB to version 10.6
  - Add `--skip-innodb-read-only-compressed` flag to MariaDB command line to workaround a Nextcloud issue (won't start without, see https://github.com/nextcloud/server/issues/25436#issuecomment-883213001)